### PR TITLE
Added a database-timeout option

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2026.7.15 -- Added a database-timeout option
+    * Added the "database-timeout" option (default 20 seconds) that controls how
+      long SEAMM waits for the job database when it is locked by another job
+      before giving up. This helps when many jobs start at the same time, for
+      example a batch of jobs on a cluster.
+
 2025.12.9 -- Added transformation for density using g/mol/Å^3
 
 2025.9.10 -- Added velocity units for speed of sound

--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,12 @@ install: uninstall ## install the package to the active Python's site-packages
 
 uninstall: clean ## uninstall the package
 	pip uninstall --yes $(MODULE)
+
+.PHONY: update
+update: ## post-release: sync main and dev, reinstall, run checks, push dev
+	git checkout main
+	git pull
+	git checkout dev
+	git merge --ff-only main
+	$(MAKE) lint install test
+	git push

--- a/seamm_util/argument_parser.py
+++ b/seamm_util/argument_parser.py
@@ -642,6 +642,18 @@ def seamm_parser(name="SEAMM"):
     )
     parser.add_argument(
         "SEAMM",
+        "--database-timeout",
+        group="job options",
+        dest="database_timeout",
+        default=20.0,
+        type=float,
+        help=(
+            "Seconds to wait for the database when it is locked by another "
+            "job before giving up, default: %(default)s"
+        ),
+    )
+    parser.add_argument(
+        "SEAMM",
         "--standalone",
         group="job options",
         action="store_true",

--- a/seamm_util/compact_json_encoder.py
+++ b/seamm_util/compact_json_encoder.py
@@ -2,6 +2,7 @@
 """From a gist by Jannis Mainczyk
 https://gist.github.com/jannismain/e96666ca4f059c3e5bc28abb711b5c92
 """
+
 from __future__ import annotations
 import json
 


### PR DESCRIPTION
* Added the "database-timeout" option (default 20 seconds) that controls how long SEAMM waits for the job database when it is locked by another job before giving up. This helps when many jobs start at the same time, for example a batch of jobs on a cluster.