### PR TITLE
Exclude _version.py from black in lint/format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 
 lint: ## check style with black and flake8
-	black --check --diff $(MODULE) tests
+	black --extend-exclude '_version.py' --check --diff $(MODULE) tests
 	flake8 $(MODULE) tests
 
 format: ## reformat with with yapf and isort
-	black $(MODULE) tests
+	black --extend-exclude '_version.py' $(MODULE) tests
 
 test: ## run tests quickly with the default Python
 	pytest --doctest-modules tests $(MODULE)


### PR DESCRIPTION
Match the standard SEAMM Makefile so `make lint` skips the versioneer-generated `_version.py`. Needed now that the devops CI runs `make lint` instead of a hardcoded black exclusion.